### PR TITLE
Migrate Inbox API URL from api2 to api

### DIFF
--- a/src/Api/Inbox.php
+++ b/src/Api/Inbox.php
@@ -8,7 +8,7 @@
     class Inbox
     {
         private GuzzleClient $client;
-        private string $base_uri = 'https://api2.logicalcms.com';
+        private string $base_uri = 'https://api.logicalcms.com';
 
         public function __construct(private string $api_key, private string $domain)
         {


### PR DESCRIPTION
## Summary
- Updates `sdk/src/Api/Inbox.php` base URI from `api2.logicalcms.com` to `api.logicalcms.com`

## ⚠️ Do NOT merge until migration day
This PR is part of the coordinated api2 → api migration. Merge only after DNS has been switched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)